### PR TITLE
Disable telemetry and streamlit magic commands

### DIFF
--- a/streamlit-app/frontend/src/.streamlit/config.toml
+++ b/streamlit-app/frontend/src/.streamlit/config.toml
@@ -2,3 +2,9 @@
 layout="wide"
 base="light"
 initial_sidebar_state="expanded"
+
+[browser]
+gatherUsageStats = false
+
+[runner]
+magicEnabled = false


### PR DESCRIPTION
Streamlit magic is impossible to understand without knowing about it from the documentation. It also makes it easier to make mistakes that end up in the front-end. I don't really see the benefit for people that are not simply quickly converting jupyter notebooks.